### PR TITLE
Fix CoordSeq bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geos"
-version = "0.3.0"
+version = "1.0.0"
 authors = ["Matthieu Viry <matthieu.viry@cnrs.fr>", "Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/georust/rust-geos"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -407,7 +407,7 @@ impl GGeom {
 
     /// get the underlying geos CoordSeq object from the geometry
     ///
-    /// Note: this clones the underlying CoordSeq not avoid double free
+    /// Note: this clones the underlying CoordSeq to avoid double free
     /// (because CoordSeq handles the object ptr and the CoordSeq is still owned by the geos geometry)
     /// if this method's performance becomes a bottleneck, feel free to open an issue, we could skip this clone with cleaner code
     pub fn get_coord_seq(&self) -> Result<CoordSeq, Error> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -38,6 +38,7 @@ extern "C" {
     fn GEOSCoordSeq_getX(s: *const GEOSCoordSequence, idx: c_uint, val: *mut c_double) -> c_int;
     fn GEOSCoordSeq_getY(s: *const GEOSCoordSequence, idx: c_uint, val: *mut c_double) -> c_int;
     fn GEOSCoordSeq_getZ(s: *const GEOSCoordSequence, idx: c_uint, val: *mut c_double) -> c_int;
+    fn GEOSCoordSeq_getSize(s: *const GEOSCoordSequence, val: *mut c_uint) -> c_int;
 
     // Geometry must be a LineString, LinearRing or Point :
     fn GEOSGeom_getCoordSeq(g: *const c_void) -> *mut GEOSCoordSequence;
@@ -310,6 +311,21 @@ impl CoordSeq {
             Err(Error::GeosError("getting coordinates from CoordSeq".into()))
         } else {
             Ok(*n_mut_ref)
+        }
+    }
+
+    pub fn len(&self) -> GeosResult<usize> {
+        let n_mut_ref = &mut 0u32;
+        let ret_val = unsafe {
+            GEOSCoordSeq_getSize(
+                self.0 as *const GEOSCoordSequence,
+                n_mut_ref as *mut c_uint,
+            )
+        };
+        if ret_val == 0 {
+            Err(Error::GeosError("getting size from CoordSeq".into()))
+        } else {
+            Ok(*n_mut_ref as usize)
         }
     }
 

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -48,14 +48,14 @@ impl<'a> TryInto<GGeom> for &'a LineRing<'a> {
     fn try_into(self) -> Result<GGeom, Self::Err> {
         let points = &(self.0).0;
         let nb_points = points.len();
-        if nb_points >= 1 && nb_points < 3 {
+        if nb_points > 0 && nb_points < 3 {
             return Err(Error::InvalidGeometry("impossible to create a LinearRing, A LinearRing must have at least 3 coordinates".into()));
         }
 
         // if the geom is not closed we close it
-        let is_closed = nb_points > 1 && points.first() == points.last();
+        let is_closed = nb_points > 0 && points.first() == points.last();
         // Note: we also need to close a 2 points closed linearring, cf test closed_2_points_linear_ring
-        let need_closing = nb_points > 1 && (! is_closed || nb_points == 3);
+        let need_closing = nb_points > 0 && (! is_closed || nb_points == 3);
         let coord_seq = if need_closing {
             create_coord_seq(points.iter().chain(std::iter::once(&points[0])), nb_points + 1)?
         } else {


### PR DESCRIPTION
A closed ring with only 2 points was crashing libgeos

the ring: [p1, p2, p1] is not valid for geos (and it thus crashes without any nice explanation).

We use the same approach as [shapely](https://shapely.readthedocs.io) a quite used geos python wrapper and  
* we close the unclosed `LinearRing`
* we consider the 2 points closed ring as a 3 points unclosed ring (with the 2 last points beeing at the same position :laughing: ) and thus close it too.

Since it was the last blocking bug for us, I propose to bump the crate version to `1.0.0` to express the fact that it will soon be used in production somewhere :stuck_out_tongue_winking_eye: 