### PR TITLE
Return a GeosResult on the various binary predicate methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geos"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Matthieu Viry <matthieu.viry@cnrs.fr>", "Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/georust/rust-geos"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let g1 = geos::GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))")?;
 let g2 = geos::GGeom::new("POLYGON ((1 1, 1 3, 5 5, 5 0, 1 1))")?;
 
 let pg1 = geos::PreparedGGeom::new(&g1);
-let result = pg1.intersects(&g2);
+let result = pg1.intersects(&g2)?;
 assert_eq!(result, true);
 ```
 

--- a/examples/from_geo.rs
+++ b/examples/from_geo.rs
@@ -30,11 +30,11 @@ fn fun() -> Result<(), Error> {
 
     let geom: GGeom = (&p).try_into()?;
 
-    assert!(geom.contains(&geom));
-    assert!(!geom.contains(&(&exterior).try_into()?));
+    assert!(geom.contains(&geom)?);
+    assert!(!geom.contains(&(&exterior).try_into()?)?);
 
-    assert!(geom.covers(&(&exterior).try_into()?));
-    assert!(geom.touches(&(&exterior).try_into()?));
+    assert!(geom.covers(&(&exterior).try_into()?)?);
+    assert!(geom.touches(&(&exterior).try_into()?)?);
     Ok(())
 }
 

--- a/examples/prepared_geom.rs
+++ b/examples/prepared_geom.rs
@@ -1,13 +1,15 @@
 extern crate geos;
+extern crate failure;
 use geos::{version, GGeom, PreparedGGeom};
+use failure::Error;
 
-fn main() {
+fn fun() -> Result<(), Error> {
     println!("geos_c version: {}", version());
-    let g1 = GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))").unwrap();
-    let g2 = GGeom::new("POLYGON ((1 1, 1 3, 5 5, 5 0, 1 1))").unwrap();
+    let g1 = GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))")?;
+    let g2 = GGeom::new("POLYGON ((1 1, 1 3, 5 5, 5 0, 1 1))")?;
     let pg1 = PreparedGGeom::new(&g1);
-    let result = pg1.intersects(&g2);
-    let result2 = pg1.contains(&g2.get_centroid().unwrap());
+    let result = pg1.intersects(&g2)?;
+    let result2 = pg1.contains(&g2.get_centroid()?)?;
     println!("Prepared geometry intersects test polygon : {:?}", result);
     println!(
         "Prepared geometry contains centroid other polygon : {:?}",
@@ -21,7 +23,12 @@ fn main() {
         GGeom::new("POINT (0.4 4.1)").unwrap(),
     ];
     for geom in &vec_geoms {
-        print!("{:?} ", pg1.intersects(&geom));
+        print!("{:?} ", pg1.intersects(&geom)?);
     }
     println!("");
+    Ok(())
+}
+
+fn main() {
+    fun().unwrap();
 }

--- a/examples/verbose_example.rs
+++ b/examples/verbose_example.rs
@@ -8,13 +8,13 @@ fn fun() -> Result<(), Error> {
     let g1 = GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))")?;
     println!("Geometry 1 created");
     println!("Area : {}", g1.area()?);
-    println!("Is Geom1 simple : {:?}", g1.is_simple());
+    println!("Is Geom1 simple : {:?}", g1.is_simple()?);
     let g2 = GGeom::new("POLYGON ((1 1, 1 3, 5 5, 5 0, 1 1))")?;
     println!("Geometry 2 created");
-    println!("Geom1 intersects geom2 : {:?}\n", g1.intersects(&g2));
+    println!("Geom1 intersects geom2 : {:?}\n", g1.intersects(&g2)?);
     let g3 = g1.buffer(100.0, 8)?;
     println!("Previous area = {} \nNew area = {}", g2.area()?, g3.area()?);
-    let result = g1.within(&g2);
+    let result = g1.within(&g2)?;
     println!("Geom1 within geom2 : {:?}\n", result);
     println!("Geom1 to wkt : {:?}", g1.to_wkt());
     let g5 = GGeom::new("LINESTRING(0.0 0.0, 7.0 7.0, 45.0 50.5, 100.0 100.0)")?;
@@ -27,7 +27,7 @@ fn fun() -> Result<(), Error> {
         "Centroid of g1 with round precision of 1: {:?}",
         g4.to_wkt_precison(Some(1))
     );
-    println!("Geom4 contains centroid of geom1 : {:?}", g3.contains(&g4));
+    println!("Geom4 contains centroid of geom1 : {:?}", g3.contains(&g4)?);
     println!("Geom4 is valid ? : {}", g3.is_valid());
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std;
+use std::{self, fmt};
 
 #[derive(Fail, Debug)]
 pub enum Error {
@@ -8,8 +8,44 @@ pub enum Error {
     ImpossibleOperation(String),
     #[fail(display = "error while calling libgeos while {}", _0)]
     GeosError(String),
+    #[fail(display = "error while calling libgeos method {} (error number = {})", _0, _1)]
+    GeosFunctionError(PredicateType, i32),
     #[fail(display = "impossible to build a geometry from a nullptr")]
     NoConstructionFromNullPtr,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum PredicateType {
+    Intersects,
+    Crosses,
+    Disjoint,
+    Touches,
+    Overlaps,
+    Within,
+    Equals,
+    EqualsExact,
+    Covers,
+    CoveredBy,
+    Contains,
+    IsRing,
+    IsEmpty,
+    IsSimple,
+    PreparedContains,
+    PreparedContainsProperly,
+    PreparedCoveredBy,
+    PreparedCovers,
+    PreparedCrosses,
+    PreparedDisjoint,
+    PreparedIntersects,
+    PreparedOverlaps,
+    PreparedTouches,
+    PreparedWithin
+}
+
+impl std::fmt::Display for PredicateType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", format!("{:?}", self))
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -453,52 +453,100 @@ impl GGeom {
         result
     }
 
-    pub fn is_ring(&self) -> bool {
+    pub fn is_ring(&self) -> GeosResult<bool> {
         let rv = unsafe { GEOSisRing(self.c_obj()) };
-        return if rv == 1 { true } else { false };
+        if rv == 1 {
+            Ok(true)
+        } else if rv == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing isRing".into()))
+        }
     }
 
-    pub fn intersects(&self, g2: &GGeom) -> bool {
+    pub fn intersects(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSIntersects(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing intersects predicate".into()))
+        }
     }
 
-    pub fn crosses(&self, g2: &GGeom) -> bool {
+    pub fn crosses(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSCrosses(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing crosses predicate".into()))
+        }
     }
 
-    pub fn disjoint(&self, g2: &GGeom) -> bool {
+    pub fn disjoint(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSDisjoint(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing disjoint predicate".into()))
+        }
     }
 
-    pub fn touches(&self, g2: &GGeom) -> bool {
+    pub fn touches(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSTouches(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing touches predicate".into()))
+        }
     }
 
-    pub fn overlaps(&self, g2: &GGeom) -> bool {
+    pub fn overlaps(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSOverlaps(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing overlaps predicate".into()))
+        }
     }
 
-    pub fn within(&self, g2: &GGeom) -> bool {
+    pub fn within(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSWithin(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing within predicate".into()))
+        }
     }
 
-    pub fn equals(&self, g2: &GGeom) -> bool {
+    pub fn equals(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSEquals(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing equals predicate".into()))
+        }
     }
 
-    pub fn equals_exact(&self, g2: &GGeom, precision: f64) -> bool {
+    pub fn equals_exact(&self, g2: &GGeom, precision: f64) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSEqualsExact(
                 self.c_obj(),
@@ -506,24 +554,48 @@ impl GGeom {
                 precision as c_double,
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing equals_exact predicate".into()))
+        }
     }
 
-    pub fn covers(&self, g2: &GGeom) -> bool {
+    pub fn covers(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSCovers(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing covers predicate".into()))
+        }
     }
 
-    pub fn covered_by(&self, g2: &GGeom) -> bool {
+    pub fn covered_by(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSCoveredBy(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing covered_by predicate".into()))
+        }
     }
 
-    pub fn contains(&self, g2: &GGeom) -> bool {
+    pub fn contains(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSContains(self.c_obj(), g2.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing contains predicate".into()))
+        }
     }
 
     pub fn buffer(&self, width: f64, quadsegs: i32) -> GeosResult<GGeom> {
@@ -536,15 +608,28 @@ impl GGeom {
         })
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSisEmpty(self.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing isEmpty".into()))
+        }
     }
 
-    pub fn is_simple(&self) -> bool {
+    pub fn is_simple(&self) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSisSimple(self.c_obj()) };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing isSimple".into()))
+        }
     }
+
     pub fn difference(&self, g2: &GGeom) -> GeosResult<GGeom> {
         GGeom::new_from_c_obj(unsafe {
             GEOSDifference(self.c_obj(), g2.c_obj())
@@ -669,94 +754,155 @@ impl PreparedGGeom {
     pub fn new(g: &GGeom) -> PreparedGGeom {
         PreparedGGeom(unsafe { GEOSPrepare(g.c_obj()) })
     }
-    pub fn contains(&self, g2: &GGeom) -> bool {
+    pub fn contains(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedContains(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing contains predicate on prepared geometry".into()))
+        }
     }
-    pub fn contains_properly(&self, g2: &GGeom) -> bool {
+    pub fn contains_properly(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedContainsProperly(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing contains_properly predicate on prepared geometry".into()))
+        }
     }
-    pub fn covered_by(&self, g2: &GGeom) -> bool {
+    pub fn covered_by(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedCoveredBy(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing covered_by predicate on prepared geometry".into()))
+        }
     }
-    pub fn covers(&self, g2: &GGeom) -> bool {
+    pub fn covers(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedCovers(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing covers predicate on prepared geometry".into()))
+        }
     }
-    pub fn crosses(&self, g2: &GGeom) -> bool {
+    pub fn crosses(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedCrosses(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing crosses predicate on prepared geometry".into()))
+        }
+
     }
-    pub fn disjoint(&self, g2: &GGeom) -> bool {
+    pub fn disjoint(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedDisjoint(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing disjoint predicate on prepared geometry".into()))
+        }
     }
-    pub fn intersects(&self, g2: &GGeom) -> bool {
+    pub fn intersects(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedIntersects(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing intersects predicate on prepared geometry".into()))
+        }
     }
-    pub fn overlaps(&self, g2: &GGeom) -> bool {
+    pub fn overlaps(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedOverlaps(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing overlaps predicate on prepared geometry".into()))
+        }
     }
-    pub fn touches(&self, g2: &GGeom) -> bool {
+    pub fn touches(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedTouches(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing touches predicate on prepared geometry".into()))
+        }
     }
-    pub fn within(&self, g2: &GGeom) -> bool {
+    pub fn within(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
             GEOSPreparedWithin(
                 self.0 as *const GEOSPreparedGeometry,
                 g2.c_obj(),
             )
         };
-        return ret_val == 1;
+        if ret_val == 1 {
+            Ok(true)
+        } else if ret_val == 0 {
+            Ok(false)
+        } else {
+            Err(Error::GeosError("computing within predicate on prepared geometry".into()))
+        }
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -455,95 +455,47 @@ impl GGeom {
 
     pub fn is_ring(&self) -> GeosResult<bool> {
         let rv = unsafe { GEOSisRing(self.c_obj()) };
-        if rv == 1 {
-            Ok(true)
-        } else if rv == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing isRing".into()))
-        }
+        check_geos_predicate(rv, PredicateType::IsRing)
     }
 
     pub fn intersects(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSIntersects(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing intersects predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Intersects)
     }
 
     pub fn crosses(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSCrosses(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing crosses predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Crosses)
     }
 
     pub fn disjoint(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSDisjoint(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing disjoint predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Disjoint)
     }
 
     pub fn touches(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSTouches(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing touches predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Touches)
     }
 
     pub fn overlaps(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSOverlaps(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing overlaps predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Overlaps)
     }
 
     pub fn within(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSWithin(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing within predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Within)
     }
 
     pub fn equals(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSEquals(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing equals predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Equals)
     }
 
     pub fn equals_exact(&self, g2: &GGeom, precision: f64) -> GeosResult<bool> {
@@ -554,48 +506,24 @@ impl GGeom {
                 precision as c_double,
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing equals_exact predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::EqualsExact)
     }
 
     pub fn covers(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSCovers(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing covers predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Covers)
     }
 
     pub fn covered_by(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSCoveredBy(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing covered_by predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::CoveredBy)
     }
 
     pub fn contains(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val =
             unsafe { GEOSContains(self.c_obj(), g2.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing contains predicate".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::Contains)
     }
 
     pub fn buffer(&self, width: f64, quadsegs: i32) -> GeosResult<GGeom> {
@@ -610,24 +538,12 @@ impl GGeom {
 
     pub fn is_empty(&self) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSisEmpty(self.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing isEmpty".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::IsEmpty)
     }
 
     pub fn is_simple(&self) -> GeosResult<bool> {
         let ret_val = unsafe { GEOSisSimple(self.c_obj()) };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing isSimple".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::IsSimple)
     }
 
     pub fn difference(&self, g2: &GGeom) -> GeosResult<GGeom> {
@@ -761,13 +677,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing contains predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedContains)
     }
     pub fn contains_properly(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -776,13 +686,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing contains_properly predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedContainsProperly)
     }
     pub fn covered_by(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -791,13 +695,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing covered_by predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedCoveredBy)
     }
     pub fn covers(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -806,13 +704,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing covers predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedCovers)
     }
     pub fn crosses(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -821,14 +713,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing crosses predicate on prepared geometry".into()))
-        }
-
+        check_geos_predicate(ret_val, PredicateType::PreparedCrosses)
     }
     pub fn disjoint(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -837,13 +722,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing disjoint predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedDisjoint)
     }
     pub fn intersects(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -852,13 +731,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing intersects predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedIntersects)
     }
     pub fn overlaps(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -867,13 +740,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing overlaps predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedOverlaps)
     }
     pub fn touches(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -882,13 +749,7 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing touches predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedTouches)
     }
     pub fn within(&self, g2: &GGeom) -> GeosResult<bool> {
         let ret_val = unsafe {
@@ -897,12 +758,71 @@ impl PreparedGGeom {
                 g2.c_obj(),
             )
         };
-        if ret_val == 1 {
-            Ok(true)
-        } else if ret_val == 0 {
-            Ok(false)
-        } else {
-            Err(Error::GeosError("computing within predicate on prepared geometry".into()))
-        }
+        check_geos_predicate(ret_val, PredicateType::PreparedWithin)
     }
+}
+
+fn check_geos_predicate(val: i32, type_pred: PredicateType) -> GeosResult<bool> {
+    match val {
+        1 => Ok(true),
+        0 => Ok(false),
+        _ => Err(on_error(type_pred))
+    }
+}
+
+enum PredicateType {
+    Intersects,
+    Crosses,
+    Disjoint,
+    Touches,
+    Overlaps,
+    Within,
+    Equals,
+    EqualsExact,
+    Covers,
+    CoveredBy,
+    Contains,
+    IsRing,
+    IsEmpty,
+    IsSimple,
+    PreparedContains,
+    PreparedContainsProperly,
+    PreparedCoveredBy,
+    PreparedCovers,
+    PreparedCrosses,
+    PreparedDisjoint,
+    PreparedIntersects,
+    PreparedOverlaps,
+    PreparedTouches,
+    PreparedWithin
+}
+
+fn on_error(type_pred: PredicateType) -> Error {
+    let name = match type_pred {
+        Intersects => "intersects",
+        Crosses => "crosses",
+        Disjoint => "disjoint",
+        Touches => "touches",
+        Overlaps => "overlaps",
+        Within => "within",
+        Equals => "equals",
+        EqualsExact => "equals_exact",
+        Covers => "covers",
+        CoveredBy => "covered_by",
+        Contains => "contains",
+        IsRing => "is_ring",
+        IsEmpty => "is_empty",
+        IsSimple => "is_simple",
+        PreparedContains => "contains",
+        PreparedContainsProperly => "contains_properly",
+        PreparedCoveredBy => "covered_by",
+        PreparedCovers => "prepared covers",
+        PreparedCrosses => "prepared crosses",
+        PreparedDisjoint => "prepared disjoint",
+        PreparedIntersects => "prepared intersects",
+        PreparedOverlaps => "prepared overlaps",
+        PreparedTouches => "prepared touches",
+        PreparedWithin => "prepared within"
+    };
+    Error::GeosError(format!("computing {} predicate)", name))
 }

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -15,7 +15,7 @@ fn create_coord_seq_from_vec<'a>(points: &'a[Point<f64>]) -> Result<CoordSeq, Er
     create_coord_seq(points.iter(), points.len())
 }
 
-fn create_coord_seq<'a, It>(points: It, len: usize) -> Result<CoordSeq, Error> 
+fn create_coord_seq<'a, It>(points: It, len: usize) -> Result<CoordSeq, Error>
 where It: Iterator<Item = &'a Point<f64>> {
     let coord_seq = CoordSeq::new(len as u32, 2);
     for (i, p) in points.enumerate() {
@@ -36,7 +36,7 @@ impl<'a> TryInto<GGeom> for &'a LineString<f64> {
     }
 }
 
-// rust geo does not have the distinction LineString/LineRing, so we create a wrapper 
+// rust geo does not have the distinction LineString/LineRing, so we create a wrapper
 
 struct LineRing<'a>(&'a LineString<f64>);
 
@@ -125,11 +125,11 @@ mod test {
 
         let geom: GGeom = (&p).try_into().unwrap();
 
-        assert!(geom.contains(&geom));
-        assert!(!geom.contains(&(&exterior).try_into().unwrap()));
+        assert!(geom.contains(&geom).unwrap());
+        assert!(!geom.contains(&(&exterior).try_into().unwrap()).unwrap());
 
-        assert!(geom.covers(&(&exterior).try_into().unwrap()));
-        assert!(geom.touches(&(&exterior).try_into().unwrap()));
+        assert!(geom.covers(&(&exterior).try_into().unwrap()).unwrap());
+        assert!(geom.touches(&(&exterior).try_into().unwrap()).unwrap());
     }
 
     #[test]
@@ -155,8 +155,8 @@ mod test {
 
         let geom: GGeom = (&mp).try_into().unwrap();
 
-        assert!(geom.contains(&geom));
-        assert!(geom.contains(&(&p).try_into().unwrap()));
+        assert!(geom.contains(&geom).unwrap());
+        assert!(geom.contains(&(&p).try_into().unwrap()).unwrap());
     }
 
     #[test]
@@ -171,8 +171,8 @@ mod test {
         let geom = (&mp).try_into();
 
         assert!(geom.is_err());
-    }    
-    
+    }
+
     #[test]
     fn incorrect_polygon_not_closed() {
         // even if the polygon is not closed we can convert it to geos (we close it)
@@ -205,7 +205,7 @@ mod test {
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());
-        assert!(geom.is_ring());
+        assert!(geom.is_ring().unwrap());
         assert_eq!(geom.get_coord_seq().unwrap().len().unwrap(), 0);
     }
 
@@ -243,7 +243,7 @@ mod test {
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());
-        assert!(geom.is_ring());
+        assert!(geom.is_ring().unwrap());
         assert_eq!(geom.get_coord_seq().unwrap().len().unwrap(), 4);
     }
 
@@ -269,7 +269,7 @@ mod test {
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());
-        assert!(geom.is_ring());
+        assert!(geom.is_ring().unwrap());
         assert_eq!(geom.get_coord_seq().unwrap().len().unwrap(), 4);
     }
 
@@ -285,7 +285,7 @@ mod test {
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());
-        assert!(geom.is_ring());
+        assert!(geom.is_ring().unwrap());
         assert_eq!(geom.get_coord_seq().unwrap().len().unwrap(), 4);
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,25 +8,25 @@ mod test {
         let line_geom = GGeom::new("LINESTRING(1 1,10 50,20 25)").unwrap();
         let polygon_geom = GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))").unwrap();
 
-        assert_eq!(true, polygon_geom.covers(&pt_geom));
-        assert_eq!(true, polygon_geom.intersects(&pt_geom));
-        assert_eq!(false, polygon_geom.covered_by(&pt_geom));
-        assert_eq!(false, polygon_geom.equals(&pt_geom));
-        assert_eq!(false, polygon_geom.within(&pt_geom));
+        assert_eq!(true, polygon_geom.covers(&pt_geom).unwrap());
+        assert_eq!(true, polygon_geom.intersects(&pt_geom).unwrap());
+        assert_eq!(false, polygon_geom.covered_by(&pt_geom).unwrap());
+        assert_eq!(false, polygon_geom.equals(&pt_geom).unwrap());
+        assert_eq!(false, polygon_geom.within(&pt_geom).unwrap());
 
-        assert_eq!(false, pt_geom.covers(&polygon_geom));
-        assert_eq!(true, pt_geom.intersects(&polygon_geom));
-        assert_eq!(true, pt_geom.covered_by(&polygon_geom));
-        assert_eq!(false, pt_geom.equals(&polygon_geom));
-        assert_eq!(true, pt_geom.within(&polygon_geom));
+        assert_eq!(false, pt_geom.covers(&polygon_geom).unwrap());
+        assert_eq!(true, pt_geom.intersects(&polygon_geom).unwrap());
+        assert_eq!(true, pt_geom.covered_by(&polygon_geom).unwrap());
+        assert_eq!(false, pt_geom.equals(&polygon_geom).unwrap());
+        assert_eq!(true, pt_geom.within(&polygon_geom).unwrap());
 
-        assert_eq!(false, line_geom.covers(&pt_geom));
-        assert_eq!(false, line_geom.intersects(&pt_geom));
-        assert_eq!(false, line_geom.covered_by(&pt_geom));
-        assert_eq!(false, pt_geom.covered_by(&line_geom));
-        assert_eq!(true, line_geom.intersects(&polygon_geom));
-        assert_eq!(true, line_geom.crosses(&polygon_geom));
-        assert_eq!(false, line_geom.equals(&pt_geom));
+        assert_eq!(false, line_geom.covers(&pt_geom).unwrap());
+        assert_eq!(false, line_geom.intersects(&pt_geom).unwrap());
+        assert_eq!(false, line_geom.covered_by(&pt_geom).unwrap());
+        assert_eq!(false, pt_geom.covered_by(&line_geom).unwrap());
+        assert_eq!(true, line_geom.intersects(&polygon_geom).unwrap());
+        assert_eq!(true, line_geom.crosses(&polygon_geom).unwrap());
+        assert_eq!(false, line_geom.equals(&pt_geom).unwrap());
     }
 
     #[test]
@@ -51,8 +51,8 @@ mod test {
         let g1 = GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))").unwrap();
         let g2 = GGeom::new("POLYGON ((1 1, 1 3, 5 5, 5 0, 1 1))").unwrap();
         let pg1 = PreparedGGeom::new(&g1);
-        assert_eq!(true, pg1.intersects(&g2));
-        assert_eq!(true, pg1.contains(&g2.get_centroid().unwrap()));
+        assert_eq!(true, pg1.intersects(&g2).unwrap());
+        assert_eq!(true, pg1.contains(&g2.get_centroid().unwrap()).unwrap());
         let vec_geoms = vec![
             GGeom::new("POINT (1.3 2.4)").unwrap(),
             GGeom::new("POINT (2.1 0.3)").unwrap(),
@@ -60,7 +60,7 @@ mod test {
             GGeom::new("POINT (0.4 4.1)").unwrap(),
         ];
         for geom in &vec_geoms {
-            assert_eq!(true, pg1.intersects(&geom));
+            assert_eq!(true, pg1.intersects(&geom).unwrap());
         }
     }
 


### PR DESCRIPTION
This PR wraps the result of the various binary predicates on `GGeom` and `PreparedGGeom` in a `GeosResult` in order to fix #10 .

I wanted to include a test case but I can't figure out how to trigger such an exception for now.

It bumps the version number to 1.1.0 as it breaks the API.